### PR TITLE
Add CPPLINT.cfg

### DIFF
--- a/checker/lint.go
+++ b/checker/lint.go
@@ -104,7 +104,7 @@ func init() {
 func (lintEnabled *LintEnabled) Init(cwd string) {
 
 	// reset to defaults
-	lintEnabled.CPP = true
+	lintEnabled.CPP = false
 	lintEnabled.Go = true
 	lintEnabled.PHP = true
 	lintEnabled.TypeScript = false
@@ -113,6 +113,9 @@ func (lintEnabled *LintEnabled) Init(cwd string) {
 	lintEnabled.ES = ""
 	lintEnabled.MD = false
 
+	if _, err := os.Stat(filepath.Join(cwd, "CPPLINT.cfg")); err == nil {
+		lintEnabled.CPP = true
+	}
 	if _, err := os.Stat(filepath.Join(cwd, ".remarkrc")); err == nil {
 		lintEnabled.MD = true
 	}

--- a/checker/message_test.go
+++ b/checker/message_test.go
@@ -75,6 +75,8 @@ func TestGenerateComments(t *testing.T) {
 			logFilePath := path.Join(testRepoPath, v.FileName+".log")
 			log, err := os.Create(logFilePath)
 			require.NoError(err)
+			defer os.Remove(logFilePath)
+			defer log.Close()
 
 			diffs, err := diff.ParseMultiFileDiff(out)
 			require.NoError(err)
@@ -92,8 +94,6 @@ func TestGenerateComments(t *testing.T) {
 					assert.Regexp(regexMessage, comments[i].Body)
 				}
 			}
-			log.Close()
-			os.Remove(logFilePath)
 		})
 	}
 }

--- a/tests/CPPLINT.cfg
+++ b/tests/CPPLINT.cfg
@@ -1,0 +1,1 @@
+set noparent


### PR DESCRIPTION
Executing cpplint only when CPPLINT.cfg exists in repo's root directory.