### PR TITLE
Fix 'Refusing to fetch into current branch'

### DIFF
--- a/checker/message.go
+++ b/checker/message.go
@@ -400,7 +400,8 @@ func HandleMessage(message string) error {
 
 	// git fetch -f https://x-access-token:token@github.com/octocat/Hello-World.git new-topic:pull-XX
 	branch := fmt.Sprintf("pull-%d", prNum)
-	// -u option can be used when fetching into current branch: https://stackoverflow.com/a/32561463/4213218
+	// -u option can be used to bypass the restriction which prevents git to fetch into current branch:
+	// link: https://stackoverflow.com/a/32561463/4213218
 	log.WriteString("$ git fetch -f -u" + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
 	cmd = exec.Command("git", "fetch", "-f", "-u", fetchURL, fmt.Sprintf("pull/%d/head:%s", prNum, branch))
 	cmd.Dir = repoPath

--- a/checker/message.go
+++ b/checker/message.go
@@ -400,8 +400,8 @@ func HandleMessage(message string) error {
 
 	// git fetch -f https://x-access-token:token@github.com/octocat/Hello-World.git new-topic:pull-XX
 	branch := fmt.Sprintf("pull-%d", prNum)
-	log.WriteString("$ git fetch -f " + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
-	cmd = exec.Command("git", "fetch", "-f", fetchURL, fmt.Sprintf("pull/%d/head:%s", prNum, branch))
+	log.WriteString("$ git fetch -f -u" + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
+	cmd = exec.Command("git", "fetch", "-f", "-u", fetchURL, fmt.Sprintf("pull/%d/head:%s", prNum, branch))
 	cmd.Dir = repoPath
 	cmd.Stdout = log
 	cmd.Stderr = log

--- a/checker/message.go
+++ b/checker/message.go
@@ -400,6 +400,7 @@ func HandleMessage(message string) error {
 
 	// git fetch -f https://x-access-token:token@github.com/octocat/Hello-World.git new-topic:pull-XX
 	branch := fmt.Sprintf("pull-%d", prNum)
+	// -u option can be used when fetching into current branch: https://stackoverflow.com/a/32561463/4213218
 	log.WriteString("$ git fetch -f -u" + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
 	cmd = exec.Command("git", "fetch", "-f", "-u", fetchURL, fmt.Sprintf("pull/%d/head:%s", prNum, branch))
 	cmd.Dir = repoPath

--- a/checker/message.go
+++ b/checker/message.go
@@ -402,7 +402,7 @@ func HandleMessage(message string) error {
 	branch := fmt.Sprintf("pull-%d", prNum)
 	// -u option can be used to bypass the restriction which prevents git from fetching into current branch:
 	// link: https://stackoverflow.com/a/32561463/4213218
-	log.WriteString("$ git fetch -f -u" + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
+	log.WriteString("$ git fetch -f -u " + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
 	cmd = exec.Command("git", "fetch", "-f", "-u", fetchURL, fmt.Sprintf("pull/%d/head:%s", prNum, branch))
 	cmd.Dir = repoPath
 	cmd.Stdout = log

--- a/checker/message.go
+++ b/checker/message.go
@@ -400,7 +400,7 @@ func HandleMessage(message string) error {
 
 	// git fetch -f https://x-access-token:token@github.com/octocat/Hello-World.git new-topic:pull-XX
 	branch := fmt.Sprintf("pull-%d", prNum)
-	// -u option can be used to bypass the restriction which prevents git to fetch into current branch:
+	// -u option can be used to bypass the restriction which prevents git from fetching into current branch:
 	// link: https://stackoverflow.com/a/32561463/4213218
 	log.WriteString("$ git fetch -f -u" + gpull.GetBase().GetRepo().GetCloneURL() + fmt.Sprintf(" pull/%d/head:%s\n", prNum, branch))
 	cmd = exec.Command("git", "fetch", "-f", "-u", fetchURL, fmt.Sprintf("pull/%d/head:%s", prNum, branch))


### PR DESCRIPTION
`-u` 选项可以解决这个问题：
[https://stackoverflow.com/questions/29028696/why-git-fetch-origin-branchbranch-works-only-on-a-non-current-branch](https://stackoverflow.com/questions/29028696/why-git-fetch-origin-branchbranch-works-only-on-a-non-current-branch)