### PR TITLE
修复 linter 检查中的时间问题

### DIFF
--- a/checker/server/handler_test.go
+++ b/checker/server/handler_test.go
@@ -65,7 +65,7 @@ func TestAddQueueHandler(t *testing.T) {
 
 	// repo PR url
 	form = url.Values{}
-	form.Set("url", "https://github.com/tengattack/playground/pull/3")
+	form.Set("url", "https://github.com/tengattack/playground/pull/2")
 	resp = newReq(uri, form.Encode())
 	assert.Equal(http.StatusOK, resp.Code)
 
@@ -77,7 +77,7 @@ func TestAddQueueHandler(t *testing.T) {
 
 	// direct url message
 	form = url.Values{}
-	form.Set("url", "https://github.com/tengattack/playground/pull/3/commits/73c5f8a45a4f02b595fbe1713ee3172749b7fc0c")
+	form.Set("url", "https://github.com/tengattack/playground/pull/2/commits/83295acbd3f4a676931c233735157b5470cef5aa")
 	resp = newReq(uri, form.Encode())
 	assert.Equal(http.StatusOK, resp.Code)
 }

--- a/checker/utils.go
+++ b/checker/utils.go
@@ -126,6 +126,7 @@ func UpdateCheckRun(ctx context.Context, client *github.Client, gpull *github.Pu
 func CreateCheckRun(ctx context.Context, client *github.Client, gpull *github.PullRequest, checkName string, ref common.GithubRef, targetURL string) (*github.CheckRun, error) {
 	checkRunStatus := "in_progress"
 
+	t := github.Timestamp{Time: time.Now()}
 	owner := gpull.GetBase().GetRepo().GetOwner().GetLogin()
 	repo := gpull.GetBase().GetRepo().GetName()
 	checkRun, _, err := client.Checks.CreateCheckRun(ctx, owner, repo, github.CreateCheckRunOptions{
@@ -133,6 +134,7 @@ func CreateCheckRun(ctx context.Context, client *github.Client, gpull *github.Pu
 		HeadSHA:    ref.Sha,
 		DetailsURL: &targetURL,
 		Status:     &checkRunStatus,
+		StartedAt:  &t,
 	})
 	return checkRun, err
 }


### PR DESCRIPTION
问题描述：

以 https://github.com/MiaoSiLa/requirements-doc/pull/1178/checks 为例，checks 中 linter 显示的与时间相关的信息不太对：
![image](https://user-images.githubusercontent.com/35494180/109935789-d57ecf00-7d08-11eb-8abc-04cd3a13c72f.png)
linter 检查成功后应该类似如下的 vulnerability 显示何时成功而不是何时开始。
![image](https://user-images.githubusercontent.com/35494180/109936680-1d9df180-7d09-11eb-9e44-6cbfdd12f485.png)


